### PR TITLE
Prepare release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased changes
+## 0.3.0
 
 - Added support for protocol version 7.
 


### PR DESCRIPTION
Simply bumps the changelog version for the new release.