### PR TITLE
`GetAccountInfo` & `GetTokenInfo` fixes

### DIFF
--- a/v2/getaccountinfo.go
+++ b/v2/getaccountinfo.go
@@ -32,10 +32,14 @@ func (c *Client) GetAccountInfo(ctx context.Context, accId *pb.AccountIdentifier
 	}
 
 	for _, t := range resp.GetTokens() {
+		state := t.GetTokenAccountState().GetBalance()
 		token := AccountToken{
 			TokenID: TokenId{Value: t.GetTokenId().GetValue()},
 			State: TokenAccountState{
-				Balance: TokenAmount{Value: t.GetTokenAccountState().GetBalance().GetValue()},
+				Balance: TokenAmount{
+					Value:    state.GetValue(),
+					Decimals: uint8(state.GetDecimals()),
+				},
 			},
 		}
 

--- a/v2/protocol-level-tokens.go
+++ b/v2/protocol-level-tokens.go
@@ -145,12 +145,19 @@ func (c *Client) GetTokenInfo(ctx context.Context, blockHash BlockHashInput, tok
 		return nil, fmt.Errorf("empty response from GetTokenInfo")
 	}
 
+	state := resp.GetTokenState()
+	tokenModuleRef := state.GetTokenModuleRef().GetValue()
+	decimals := state.GetDecimals()
+	totalSupply := state.GetTotalSupply().GetValue()
+	moduleState := state.GetModuleState().GetValue()
+
 	var tokenState *TokenState
 	if resp.TokenState != nil {
 		tokenState = &TokenState{
-			ModuleState: RawCBOR{
-				Bytes: resp.TokenState.ModuleState.Value,
-			},
+			TokenModuleRef: TokenModuleRef{Value: tokenModuleRef},
+			Decimals:       uint8(decimals),
+			TotalSupply:    TokenAmount{Value: totalSupply},
+			ModuleState:    RawCBOR{Bytes: moduleState},
 		}
 	}
 

--- a/v2/tests/tokenoperations_test.go
+++ b/v2/tests/tokenoperations_test.go
@@ -1,9 +1,10 @@
 package tests_test
 
 import (
-	v2 "github.com/Concordium/concordium-go-sdk/v2"
 	"reflect"
 	"testing"
+
+	v2 "github.com/Concordium/concordium-go-sdk/v2"
 
 	"github.com/fxamacker/cbor/v2"
 )
@@ -20,7 +21,7 @@ func TestTokenOperations_MarshalUnmarshal(t *testing.T) {
 				Transfer: v2.TokenTransfer{
 					Amount:    v2.TokenAmount{Value: 42},
 					Recipient: v2.CborTokenHolder{},
-					Memo:      v2.CborMemo{},
+					Memo:      &v2.CborMemo{},
 				},
 			},
 			new: func() v2.TokenOperation { return &v2.TransferOperation{} },

--- a/v2/tokenoperations.go
+++ b/v2/tokenoperations.go
@@ -172,7 +172,7 @@ type TokenListUpdateDetails struct {
 type TokenTransfer struct {
 	Amount    TokenAmount
 	Recipient CborTokenHolder
-	Memo      CborMemo
+	Memo      *CborMemo `cbor:"Memo,omitempty"`
 }
 
 type CborTokenHolder struct {
@@ -180,8 +180,8 @@ type CborTokenHolder struct {
 }
 
 type CborHolderAccount struct {
-	CoinInfo *CoinInfo      `cbor:"1,omitempty" json:"coinInfo,omitempty"`
-	Address  AccountAddress `cbor:"3" json:"address"`
+	CoinInfo *CoinInfo      `cbor:"1,keyasint,omitempty"`
+	Address  AccountAddress `cbor:"3,keyasint"`
 }
 
 type CoinInfo uint64 // constant ccd 919

--- a/v2/transactions/construct/tokenupdateoperation.go
+++ b/v2/transactions/construct/tokenupdateoperation.go
@@ -1,12 +1,13 @@
 package construct
 
 import (
-	v2 "github.com/Concordium/concordium-go-sdk/v2"
 	"github.com/fxamacker/cbor/v2"
+
+	v2 "github.com/Concordium/concordium-go-sdk/v2"
 )
 
 func TokenUpdateOperation(numSigs uint32, sender v2.AccountAddress, nonce v2.SequenceNumber, expiry v2.TransactionTime, tokenId v2.TokenId, operations v2.TokenOperations,
-) *v2.PreAccountTransaction {
+) (*v2.PreAccountTransaction, error) {
 	txEnergy := operations.TxnEnergy()
 	energy := &v2.GivenEnergy{Energy: &v2.AddEnergy{
 		NumSigs: numSigs,
@@ -14,14 +15,14 @@ func TokenUpdateOperation(numSigs uint32, sender v2.AccountAddress, nonce v2.Seq
 	}}
 	rawOps, err := MarshalTokenOperationsToCBORArray(operations)
 	if err != nil {
-		panic("failed to marshal operations: " + err.Error())
+		return &v2.PreAccountTransaction{}, err
 	}
 
 	payload := &v2.TokenUpdate{Payload: &v2.TokenOperationsPayload{
 		TokenId:    tokenId,
 		Operations: rawOps}}
 
-	return makeTransaction(sender, nonce, expiry, energy, &v2.AccountTransactionPayload{Payload: payload})
+	return makeTransaction(sender, nonce, expiry, energy, &v2.AccountTransactionPayload{Payload: payload}), nil
 }
 
 func MarshalTokenOperationsToCBORArray(ops v2.TokenOperations) (v2.RawCBOR, error) {

--- a/v2/transactions/send/tokenupdateoperation.go
+++ b/v2/transactions/send/tokenupdateoperation.go
@@ -10,5 +10,10 @@ import (
 // / of the token update operations encoded in the given CBOR.
 func TokenUpdateOperation(sender v2.AccountAddress, signer v2.ExactSizeTransactionSigner, nonce v2.SequenceNumber,
 	expiry v2.TransactionTime, tokenId v2.TokenId, operations v2.TokenOperations) (*v2.AccountTransaction, error) {
-	return construct.TokenUpdateOperation(signer.NumberOfKeys(), sender, nonce, expiry, tokenId, operations).Sign(signer)
+	preUpdInstruction, err := construct.TokenUpdateOperation(signer.NumberOfKeys(), sender, nonce, expiry, tokenId, operations)
+	if err != nil {
+		return nil, err
+	}
+
+	return preUpdInstruction.Sign(signer)
 }


### PR DESCRIPTION
## Purpose

getaccountinfo.go `GetAccountInfo` and protocol-level-tokens.go `GetTokenInfo` extended return information from grpc

## Changes

- Extended `TokenState` in `GetTokenInfo` method
- Extended `AccountToken` in `GetAccountInfo` method

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
